### PR TITLE
Enable PS256 signing by default on oauth apps and add a checkbox for existing apps

### DIFF
--- a/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Create.cshtml.cs
+++ b/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Create.cshtml.cs
@@ -62,6 +62,7 @@ public class Create : PageModel
                 new() { Scope = "profile" },
                 new() { Scope = "email" }
             },
+            AllowedIdentityTokenSigningAlgorithms = "PS256",
             RedirectUris = new List<ClientRedirectUri>
             {
                 new() { RedirectUri = Input.CallbackUrl }

--- a/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Manage.cshtml
+++ b/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Manage.cshtml
@@ -45,6 +45,12 @@
                     <label asp-for="Input.RequirePkce" class="form-check-label"></label>
                 </div>
             </div>
+            <div class="form-group">
+                <div class="form-check">
+                    <input asp-for="Input.AllowPS256" class="form-check-input"/>
+                    <label asp-for="Input.AllowPS256" class="form-check-label"></label>
+                </div>
+            </div>
             <button type="submit" asp-page-handler="Update" class="btn btn-primary">Update</button>
         </form>
         <div class="col-lg-6">

--- a/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Manage.cshtml.cs
+++ b/SS14.Web/Areas/Identity/Pages/Account/Manage/OAuthApps/Manage.cshtml.cs
@@ -44,6 +44,10 @@ public class Manage : PageModel
         [Required]
         [DisplayName("Require PKCE")]
         public bool RequirePkce { get; set; }
+        
+        [Required]
+        [DisplayName("Allow PS256 signing")]
+        public bool AllowPS256 { get; set; } = true;
     }
 
     public Manage(ApplicationDbContext dbContext, UserManager<SpaceUser> userManager)
@@ -62,7 +66,8 @@ public class Manage : PageModel
             Name = App.Client.ClientName,
             CallbackUrl = App.Client.RedirectUris.FirstOrDefault()?.RedirectUri ?? "",
             HomepageUrl = App.Client.ClientUri,
-            RequirePkce = App.Client.RequirePkce
+            RequirePkce = App.Client.RequirePkce,
+            AllowPS256 = App.Client.AllowedIdentityTokenSigningAlgorithms?.Contains("PS256") ?? false
         };
 
         return Page();
@@ -77,6 +82,7 @@ public class Manage : PageModel
         App.Client.RedirectUris = new List<ClientRedirectUri> { new() { RedirectUri = Input.CallbackUrl } };
         App.Client.ClientUri = Input.HomepageUrl;
         App.Client.RequirePkce = Input.RequirePkce;
+        App.Client.AllowedIdentityTokenSigningAlgorithms = Input.AllowPS256 ? "PS256" : null;
 
         await _dbContext.SaveChangesAsync();
 


### PR DESCRIPTION
No more manually having to edit it if someone wants to setup a wiki.

Fixes #11 

Might cause issues if there ever comes a point where an admin changes AllowedIdentityTokenSigningAlgorithms since touching the checkbox overrides those changes, but I dont really see that being an issue nor do I see how something like that could be abused