### PR TITLE
Make the default page the manage page

### DIFF
--- a/SS14.Web/Controllers/HomeController.cs
+++ b/SS14.Web/Controllers/HomeController.cs
@@ -1,22 +1,14 @@
 ﻿using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 using SS14.Web.Models;
 
 namespace SS14.Web.Controllers;
 
 public class HomeController : Controller
 {
-    private readonly ILogger<HomeController> _logger;
-
-    public HomeController(ILogger<HomeController> logger)
-    {
-        _logger = logger;
-    }
-
     public IActionResult Index()
     {
-        return View();
+        return Redirect("/Identity/Account/Manage");
     }
 
     public IActionResult Privacy()

--- a/SS14.Web/Views/Home/Index.cshtml
+++ b/SS14.Web/Views/Home/Index.cshtml
@@ -1,8 +1,0 @@
-﻿@{
-    ViewData["Title"] = "Home Page";
-}
-
-<h1>Space Station 14 - AuthHub</h1>
-
-This website is for managing your Space Station 14 account. Yes that's all it's for.
-<br>


### PR DESCRIPTION
The current index page is kinda useless, theres no useful information on it and most people are just logging in for the account management options. There is no point to the index page other then create confussion on how to get to the account settings page (It is not very obvious you have to click on the "Hello XYZ" link) right now and is much better to just redirect to the Management page directly.

If you are not logged in you will be sent to the login screen, where theres 2 different places to click to signup for a new user. Hard to miss.
